### PR TITLE
Update CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2223S2-CS2103-W17-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2223S2-CS2103-W17-1/tp/actions)
 [![codecov](https://codecov.io/gh/AY2223S2-CS2103-W17-1/tp/branch/master/graph/badge.svg?token=XXJ15FVPPS)](https://codecov.io/gh/AY2223S2-CS2103-W17-1/tp)
 
 ![Ui](docs/images/Ui.png)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * This is **a product for private Math tuition teachers**.<br>
   Example usages:
-  * as an application to manage their students contacts and performance
+  * as an application to manage their students' contacts and performances.
 * The project simulates an ongoing software project for a desktop application (called _MATHTUTORING_) used for managing students contacts and performance
   * It is **written in OOP fashion**. It provides a **reasonably well-written** code base based on the original project **AB3**.
   * It comes with a **reasonable level of user and developer documentation**.


### PR DESCRIPTION
Changed the Java CI badge link in README.md because the previous CI badge is referring to AddressBook's CI badge